### PR TITLE
Fix Webpack errors in Linux and other unix-based systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "marked": "^4.0.17",
     "mime-types": "^2.1.35",
     "mustache": "^4.2.0",
+    "sass": "^1.53.0",
     "url-parse": "^1.5.10",
     "utf8": "^3.0.0",
     "vanilla-picker": "^2.11.2",

--- a/src/components/WebComponents/components.js
+++ b/src/components/WebComponents/components.js
@@ -1,4 +1,4 @@
 import '@ungap/custom-elements';
-import WcPage from './WcPage';
+import WcPage from './wcPage';
 
 customElements.define('wc-page', WcPage);

--- a/src/components/commandPallete.js
+++ b/src/components/commandPallete.js
@@ -1,7 +1,7 @@
 import tag from 'html-tag-js';
 import Commands from '../lib/ace/commands';
 import helpers from '../lib/utils/helpers';
-import inputhints from './inputHints';
+import inputhints from './inputhints';
 
 export async function commandPallete() {
   const recentlyUsedCommands = RecentlyUsedCommands();

--- a/src/components/dialogboxes/multiprompt.js
+++ b/src/components/dialogboxes/multiprompt.js
@@ -1,6 +1,6 @@
 import tag from 'html-tag-js';
 import autosize from 'autosize';
-import inputhints from '../inputHints';
+import inputhints from '../inputhints';
 import Checkbox from '../checkbox';
 import alert from './alert';
 

--- a/src/components/page.js
+++ b/src/components/page.js
@@ -1,5 +1,5 @@
 import tag from "html-tag-js";
-import WCPage from "./WebComponents/WcPage";
+import WCPage from "./WebComponents/wcPage";
 
 /**
  *


### PR DESCRIPTION
This PR should fix Webpack errors when compiling on Linux or other unix-based systems.
If applied, it should also resolve issue #410.

I've tested this PR on a containerized Debian Testing with node.js 14.17.6, so those changes should work on F-Droid build servers too.

Ps. I've added sass module to package.json, because without it, I had 72 errors about .sass files in Webpack on my different machine.