### PR TITLE
Fixing acode.getFormatterFor returns undefined

### DIFF
--- a/src/lib/acode.js
+++ b/src/lib/acode.js
@@ -106,6 +106,7 @@ export default class Acode {
   /**
    * 
    * @param {string[]} extensions 
+   * @returns {Array<[id: String, name: String]>} options
    */
   getFormatterFor(extensions) {
     const options = [[null, strings.none]];
@@ -115,5 +116,6 @@ export default class Acode {
         options.push([id, name]);
       }
     });
+    return options;
   }
 }


### PR DESCRIPTION
```js 
const options = acode.getFormatterFor(extensions);
```
[defaultFormatter.js#L14](https://github.com/deadlyjack/Acode/blob/main/src/settings/defaultFormatter.js#L14)