### PR TITLE
Register extra mime typea to open json, js, sh and xml files.

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -50,6 +50,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <data android:mimeType="text/*"/>
                 <data android:mimeType="xml/*" />
+                <data android:mimeType="application/text" />
+                <data android:mimeType="application/xml" />
+                <data android:mimeType="application/json" />
+                <data android:mimeType="application/javascript" />
+                <data android:mimeType="application/x-sh" />
+                <data android:mimeType="application/octet-stream"/>
+                <data pathPattern=".*\.txt"/>
+                <data pathPattern=".*\.xml"/>
+                <data pathPattern=".*\.json"/>
             </intent-filter>
         </config-file>
 


### PR DESCRIPTION
This allows Acode to be registered as the default application to open more file types.

When using MiXplorer file browser in particular, it presents a list of apps to use to open any particular file based on its type, eg.
![Screenshot_20221207-194942](https://user-images.githubusercontent.com/3318786/206788854-bbd182e3-cdb4-44ed-92d2-9a95314949b2.png)
![Screenshot_20221209-013036](https://user-images.githubusercontent.com/3318786/206789214-2bf87b5e-8214-485d-a799-07051d38b2d7.png)


This PR extends the list of supported file types to suggest using acode for these files :-)
![Screenshot_20221209-012848](https://user-images.githubusercontent.com/3318786/206789046-40a6f5ff-8d5f-48da-aa63-7c3840d747f2.png)
