### PR TITLE
Fix quicktools searching issue

### DIFF
--- a/src/handlers/quickTools.js
+++ b/src/handlers/quickTools.js
@@ -317,8 +317,8 @@ function find(skip, backward) {
   const { $searchInput } = quickTools;
   editorManager.editor.find($searchInput.value, {
     skipCurrent: skip,
-    backwards: backward,
     ...appSettings.value.search,
+    backwards: backward,
   });
 
   updateSearchState();


### PR DESCRIPTION
Legacy settings has a key call 'backwards' in search settings that cause it to override the input to always search backwards

Fixes #809.

Note:  it used to be like this before the search change, backwards key/value get set after the settings


eg settings:
```json
    "search": {
        "caseSensitive": false,
        "regExp": false,
        "wholeWord": false,
        "backwards": true
    },
```


broken by https://github.com/deadlyjack/Acode/commit/82d147f8676034afcf1caa4deba5143f0d43fd26#diff-b46b01d6ed020a238065127cc51634b279fee3fe600705414a2ad9ef20052914L266

before:
https://github.com/deadlyjack/Acode/blob/08f8bb21650c0489967baa1aa1af021155a90889/src/handlers/quickTools.js#L266-L272

after:
https://github.com/deadlyjack/Acode/blob/82d147f8676034afcf1caa4deba5143f0d43fd26/src/handlers/quickTools.js#L292-L298

this change the order back to the before, so that it works properly for pre 1.8.4 users