### PR TITLE
fix(checkPluginsUpdate): Not All Plugins Status due to `Promise.all` Rejection

### DIFF
--- a/src/lib/checkPluginsUpdate.js
+++ b/src/lib/checkPluginsUpdate.js
@@ -25,6 +25,6 @@ export default async function checkPluginsUpdate() {
 		);
 	});
 
-	await Promise.all(promises);
+	await Promise.allSettled(promises);
 	return updates;
 }


### PR DESCRIPTION
Attempts to Fix were All Plugins Statuses are not Fetched(if a promise rejects) Due to usage of 'Promise.all'(it rejects when any of the input's promises rejects, with this first rejection reason.)