### PR TITLE
feat: copy/cut current line on empty selection

### DIFF
--- a/src/lib/editorManager.js
+++ b/src/lib/editorManager.js
@@ -386,6 +386,7 @@ async function EditorManager($header, $body) {
 		editor.setOption("printMarginColumn", settings.printMargin);
 		editor.setOption("enableBasicAutocompletion", true);
 		editor.setOption("enableLiveAutocompletion", settings.liveAutoCompletion);
+		editor.setOption("copyWithEmptySelection", true);
 		// editor.setOption('enableInlineAutocompletion', settings.inlineAutoCompletion);
 
 		updateMargin(true);


### PR DESCRIPTION
## Summary
A simple solution for copying/cutting the current line if there are no selected text.

## Related Issue
Closes #1082

## Notes
We could also add an option to toggle this on and off.