### PR TITLE
style(ci): Replace unnecessary `\n`s in nightly release message

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -210,7 +210,8 @@
               platforms/android/app/build/outputs/apk/debug/app-debug.apk
             body: |
               Automated Nightly (pre-release) Releases for Today
-              \n\n[Compare Changes](https://github.com/${{ github.repository }}/compare/${{ env.TAG_COMMIT }}...${{ github.sha }})
+              
+              [Compare Changes](https://github.com/${{ github.repository }}/compare/${{ env.TAG_COMMIT }}...${{ github.sha }})
 
         - name: Update Last Comment by bot (If ran in PR)
           if: inputs.is_PR


### PR DESCRIPTION
<img width="401" height="462" alt="Screenshot_20251006-164430_Chrome Beta" src="https://github.com/user-attachments/assets/9e9f79c0-a2aa-49c7-b617-3089be68a369" />
<img width="529" height="467" alt="Screenshot_20251006-164627_GitHub" src="https://github.com/user-attachments/assets/8e470174-1831-4941-9f45-39855b47f572" />
