### PR TITLE
Add confirmation prompt before closing terminal tabs

### DIFF
--- a/src/components/terminal/terminalDefaults.js
+++ b/src/components/terminal/terminalDefaults.js
@@ -14,6 +14,7 @@ export const DEFAULT_TERMINAL_SETTINGS = {
 	letterSpacing: 0,
 	imageSupport: false,
 	fontLigatures: false,
+	confirmTabClose: true,
 	// Touch selection settings
 	touchSelectionTapHoldDuration: 600,
 	touchSelectionMoveThreshold: 8,

--- a/src/settings/terminalSettings.js
+++ b/src/settings/terminalSettings.js
@@ -166,6 +166,12 @@ export default function terminalSettings() {
 			info: "Whether font ligatures are enabled in the terminal.",
 		},
 		{
+			key: "confirmTabClose",
+			text: `${strings["confirm"]} ${strings["terminal"]} tab close`,
+			checkbox: terminalValues.confirmTabClose !== false,
+			info: "Ask for confirmation before closing terminal tabs.",
+		},
+		{
 			key: "backup",
 			text: strings.backup.capitalize(),
 			info: "Creates a backup of the terminal installation",


### PR DESCRIPTION
Introduces a new setting 'confirmTabClose' to prompt users for confirmation before closing terminal tabs. The setting is added to the default terminal settings and terminal settings UI, and the terminal manager now checks this setting before closing a terminal tab.