### PR TITLE
Fix: Truncate cache files before writing to prevent content corruption

### DIFF
--- a/src/fileSystem/internalFs.js
+++ b/src/fileSystem/internalFs.js
@@ -49,15 +49,12 @@ const internalFs = {
 						{ create, exclusive },
 						(fileEntry) => {
 							fileEntry.createWriter((writer) => {
-								writer.onerror = (err) => reject(err.target.error);
-								// Truncate file to 0 to clear any old content
-								// This prevents trailing garbage when new data is smaller than old data
-								writer.truncate(0);
-								writer.onwriteend = () => {
-									// After truncate completes, write new data
-									writer.onwriteend = (res) => resolve(filename);
+								writer.onerror = (e) => reject(e.target.error);
+								writer.onwrite = () => {
+									writer.onwrite = () => resolve(filename);
 									writer.write(data);
 								};
+								writer.truncate(0);
 							});
 						},
 						reject,


### PR DESCRIPTION
This bugfix relates to Issue [#1436](https://github.com/Acode-Foundation/Acode/issues/1436).

Note: This issue was analyzed and implemented using Claude Code. The solution is coherent to me but I do not have insight on the project.

**This implementation is not tested!**

## Problem
SFTP files (and other cached remote files) sometimes display mixed content from different files.
   Specifically:
  - The beginning of the file shows the correct content
  - Trailing portions contain random content from previously cached files
  - Most commonly observed with files sharing the same name in different directories (e.g. `vars/main.yml`)

Actual content:
<img width="864" height="1920" alt="actual_content" src="https://github.com/user-attachments/assets/b6302e5c-7bbf-406a-90e4-690a030be72e" />

Acode content:
<img width="864" height="1920" alt="acode_content" src="https://github.com/user-attachments/assets/1630422a-3114-4e16-b010-bbf00a5499e1" />

  ### Root Cause
  The `internalFs.writeFile()` function in `src/fileSystem/internalFs.js` uses the Cordova FileWriter API without truncating the file before writing. When writing new content that is  **shorter** than the existing cached file, the old trailing data remains in the file.

  **Example:**
  1. Cache file contains: `"Long content from project1/vars/main.yml with lots of data..."`
  2. User opens: `project2/vars/main.yml` (shorter file)
  3. SFTP downloads: `"Short YAML"`
  4. **Result**: `"Short YAMLt from project1/vars/main.yml with lots of data..."` ❌

  ### Performance Impact
  - Adds one additional async operation (truncate)
  - Modern filesystems optimize this efficiently (metadata update + block reuse)
  - Negligible performance impact compared to correctness gain

  ### Affected Areas
  - SFTP file caching (most common)
  - FTP file caching
  - Any operation using `internalFs.writeFile()` with existing files

