### PR TITLE
fix(terminal): cleanup broken tabs and show alerts on terminal errors

### DIFF
--- a/src/components/terminal/terminalManager.js
+++ b/src/components/terminal/terminalManager.js
@@ -573,15 +573,7 @@ class TerminalManager {
 			console.error(`Terminal ${terminalId} error:`, error);
 
 			// Close the terminal and remove the tab
-			this.closeTerminal(terminalId);
-
-			// Force remove the tab
-			try {
-				terminalFile._skipTerminalCloseConfirm = true;
-				terminalFile.remove(true);
-			} catch (removeError) {
-				console.error("Error removing terminal tab:", removeError);
-			}
+			this.closeTerminal(terminalId, true);
 
 			// Show alert for connection error
 			const errorMessage = error?.message || "Connection lost";


### PR DESCRIPTION
Fixes: #1771 

- Properly dispose and remove failed terminal tabs instead of leaving them stuck
- Use alert dialogs instead of toasts for terminal creation/connection errors
- Show consolidated error messages for failed session restorations
- Fix memory leak in ResizeObserver cleanup