### PR TITLE
Fix: Remove trimming of matched content in Executor.js

### DIFF
--- a/src/plugins/terminal/www/Executor.js
+++ b/src/plugins/terminal/www/Executor.js
@@ -47,7 +47,7 @@ class Executor {
             const match = message.match(/^([^:]+):(.*)$/);
             if (match) {
               const prefix = match[1];         // e.g. "stdout"
-              const content = match[2].trim(); // output
+              const content = match[2]; // output
               onData(prefix, content);
             } else {
               onData("unknown", message);


### PR DESCRIPTION
The output should not be trimmed. Using trim() breaks streamed output (line-by-line) because it removes leading spaces. This results in invalid output for many use cases, such as diffs and git status symbol.