### PR TITLE
Added Documents viewer plugin id to load pdf/excel/csv etc. files

### DIFF
--- a/src/lib/loadPlugins.js
+++ b/src/lib/loadPlugins.js
@@ -22,6 +22,7 @@ const THEME_IDENTIFIERS = new Set([
 	"moonlight",
 	"bluloco",
 	"acode.plugin.extra_syntax_highlights",
+	"documentsviewer",
 ]);
 
 export const onPluginLoadCallback = Symbol("onPluginLoadCallback");


### PR DESCRIPTION
the Documents Viewer plugin/extension provides the view support for multiple types of documents like `pdf, csv, xlsx, docs etc..` developed and maintained by user 1446 `HACKESOFICE`.

## Problem
> when user opens these files directly through file manager =>  open with Acode then Acode opens these files directly to the text editor, which is not useful as these files are binary files.

## Reason
> Acode at first ( startup ) loads only plugins which are listed in List / Arrary ( HEME_IDENTIFIERS ) then other plugins ( Documents viewer also ) are loaded after Successful app startup. so the file handlers are registering after file load and user see's only bytes as text.## Solution> Added The Documents Viewer plugin id ( Which is "documentsviewer" )  in HEME_IDENTIFIERS List / Array.

## Expected Workflow / behavior 
>Clicks on Acode app => load all plugins with the id available in HEME_IDENTIFIERS ( Now Documents Viewer Also ) => then Load Files.

## Why It'll Work
> Because of Acode will now load the plugin ( if available ) at startup so all the file handlers will be registered before loading/opening the particular files.