### PR TITLE
feat(settings): add swatch previews to theme settings

### DIFF
--- a/src/pages/themeSetting/themeSetting.js
+++ b/src/pages/themeSetting/themeSetting.js
@@ -3,7 +3,7 @@ import { javascript } from "@codemirror/lang-javascript";
 // For CodeMirror preview
 import { EditorState } from "@codemirror/state";
 import { oneDark } from "@codemirror/theme-one-dark";
-import { getThemeExtensions, getThemes } from "cm/themes";
+import { getThemeConfig, getThemeExtensions, getThemes } from "cm/themes";
 import { basicSetup, EditorView } from "codemirror";
 import Page from "components/page";
 import searchBar from "components/searchbar";
@@ -111,15 +111,16 @@ export default function () {
 
 		const currentTheme = appSettings.value.appTheme;
 		let $currentItem;
-		themes.list().forEach((theme) => {
+		themes.list().forEach((themeSummary) => {
+			const theme = themes.get(themeSummary.id);
 			const isCurrentTheme = theme.id === currentTheme;
 			const isPremium = theme.version === "paid" && IS_FREE_VERSION;
 			const $item = (
 				<Item
-					name={theme.name}
+					name={themeSummary.name}
 					isPremium={isPremium}
 					isCurrent={isCurrentTheme}
-					color={theme.primaryColor}
+					swatches={getAppThemeSwatches(theme)}
 					onclick={() => setAppTheme(theme, isPremium)}
 				/>
 			);
@@ -150,7 +151,7 @@ export default function () {
 				<Item
 					name={t.caption}
 					isCurrent={isCurrent}
-					isDark={t.isDark}
+					swatches={getEditorThemeSwatches(t.id)}
 					onclick={() => setEditorTheme({ caption: t.caption, theme: t.id })}
 				/>
 			);
@@ -245,19 +246,9 @@ export default function () {
 		list.get(`[theme="${theme}"]`)?.check();
 	}
 
-	function Item({ name, color, isDark, onclick, isCurrent, isPremium }) {
+	function Item({ name, swatches, onclick, isCurrent, isPremium }) {
 		const check = <span className="icon check"></span>;
 		const star = <span className="icon stars"></span>;
-		let style = {};
-		let className = "icon color";
-
-		if (color) {
-			style = { color };
-		} else if (isDark) {
-			className += " dark";
-		} else {
-			className += " light";
-		}
 
 		const $el = (
 			<div
@@ -266,7 +257,7 @@ export default function () {
 				className="list-item"
 				onclick={onclick}
 			>
-				<span style={style} className={className}></span>
+				{createSwatchPreview(swatches)}
 				<div className="container">
 					<span className="text">{name}</span>
 				</div>
@@ -284,5 +275,52 @@ export default function () {
 			$el.setAttribute("checked", true);
 		};
 		return $el;
+	}
+
+	function createSwatchPreview(swatches) {
+		const colors = [...new Set((swatches || []).filter(Boolean))].slice(0, 3);
+		while (colors.length < 3) {
+			colors.push(colors[colors.length - 1] || "var(--border-color)");
+		}
+
+		return (
+			<div className="theme-swatch-slot" aria-hidden="true">
+				<div className="theme-swatch-preview">
+					<span
+						className="theme-swatch theme-swatch-main"
+						style={{ backgroundColor: colors[0] }}
+					></span>
+					<span
+						className="theme-swatch"
+						style={{ backgroundColor: colors[1] }}
+					></span>
+					<span
+						className="theme-swatch"
+						style={{ backgroundColor: colors[2] }}
+					></span>
+				</div>
+			</div>
+		);
+	}
+
+	function getAppThemeSwatches(theme) {
+		if (!theme) {
+			return [
+				"var(--primary-color)",
+				"var(--secondary-color)",
+				"var(--active-color)",
+			];
+		}
+
+		return [theme.primaryColor, theme.secondaryColor, theme.activeColor];
+	}
+
+	function getEditorThemeSwatches(themeId) {
+		const config = getThemeConfig(themeId);
+		return [
+			config.background,
+			config.keyword || config.function || config.foreground,
+			config.string || config.variable || config.foreground,
+		];
 	}
 }

--- a/src/pages/themeSetting/themeSetting.scss
+++ b/src/pages/themeSetting/themeSetting.scss
@@ -9,11 +9,47 @@
     pointer-events: none;
   }
 
-  .icon.color.custom::before {
-    background-color: var(--primary-color);
+  #theme-preview .cm-editor {
+    width: 100%;
   }
 
   #theme-list {
     flex: 1;
+  }
+
+  .theme-swatch-slot {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 60px;
+    min-width: 60px;
+    height: 60px;
+    flex-shrink: 0;
+  }
+
+  .theme-swatch-preview {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.72fr);
+    grid-template-rows: repeat(2, minmax(0, 1fr));
+    width: 1.5rem;
+    min-width: 1.5rem;
+    height: 1.5rem;
+    padding: 0.08rem;
+    box-sizing: border-box;
+    border: 1px solid var(--border-color);
+    border: 1px solid color-mix(in srgb, var(--border-color), transparent 18%);
+    border-radius: 0.45rem;
+    background: var(--secondary-color);
+    overflow: hidden;
+  }
+
+  .theme-swatch {
+    display: block;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .theme-swatch-main {
+    grid-row: 1 / 3;
   }
 }


### PR DESCRIPTION
- add square swatch previews to app theme items
- add square swatch previews to editor theme items


## Demo

| Before | After |
|-------|---------|
| <img width="560" height="1974" alt="Screenshot_20260308-182233 Acode" src="https://github.com/user-attachments/assets/28914595-f867-4ac5-ad51-ce09ddac93c7" /> | <img width="444" height="1989" alt="Screenshot_20260308-182144 Acode" src="https://github.com/user-attachments/assets/32ebfec6-7436-42dd-8cb3-8e743a703a48" /> |
| <img width="721" height="1360" alt="Screenshot_20260308-182248 Acode" src="https://github.com/user-attachments/assets/ef303e2c-29ac-4f02-b6d8-2aaa620ee892" /> | <img width="563" height="1351" alt="Screenshot_20260308-182203 Acode" src="https://github.com/user-attachments/assets/4d367b6b-a2f1-4e06-937d-19198adf3339" /> |